### PR TITLE
Rebuild pharmacy filter options on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,14 +556,22 @@
       const select = $('#filter-pharmacy');
       const current = select.value;
       const pharmacies = [...new Set(payments.map(p => p.pharmacy))].sort();
-      
-      if (select.options.length <= 1) { // Solo llenar si está vacío para no resetear selección
-        pharmacies.forEach(ph => {
-          const opt = document.createElement('option');
-          opt.value = ph; opt.textContent = ph;
-          select.appendChild(opt);
-        });
-      }
+      const fragment = document.createDocumentFragment();
+      const allOption = document.createElement('option');
+      allOption.value = '';
+      allOption.textContent = '🏥 Todas las farmacias';
+      fragment.appendChild(allOption);
+
+      pharmacies.forEach(ph => {
+        const opt = document.createElement('option');
+        opt.value = ph;
+        opt.textContent = ph;
+        fragment.appendChild(opt);
+      });
+
+      select.textContent = '';
+      select.appendChild(fragment);
+      select.value = pharmacies.includes(current) ? current : '';
     }
 
     // --- ACCIONES CRUD ---


### PR DESCRIPTION
### Motivation
- Reconstruir dinámicamente las opciones del filtro de farmacia en cada actualización para evitar opciones obsoletas y mantener la selección previa cuando aún exista.
- Minimizar reflows al agregar múltiples opciones usando un `DocumentFragment`.
- Garantizar que la opción por defecto `Todas las farmacias` esté siempre presente al inicio del `select`.

### Description
- En `index.html` la función `updateFiltersUI(payments)` ahora genera un `DocumentFragment`, agrega la opción por defecto y las farmacias únicas ordenadas, y reemplaza las opciones del `select`.
- Se limpia el contenido previo con `select.textContent = ''` y se inserta el fragmento para evitar reflows.
- Se restaura la selección previa con `select.value = pharmacies.includes(current) ? current : '';` cuando la farmacia seleccionada aún existe.

### Testing
- No se ejecutaron pruebas automatizadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bf3d25e0832a8a3842002dd98292)