### PR TITLE
Use getDoc for payment details and add normalization/guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -354,7 +354,7 @@
     import { initializeApp } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js";
     import { getAnalytics } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-analytics.js";
     import {
-      getFirestore, collection, addDoc, getDocs, deleteDoc, doc, query, where, orderBy, updateDoc
+      getFirestore, collection, addDoc, getDocs, getDoc, deleteDoc, doc, query, orderBy, updateDoc
     } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js";
 
     // --- CONFIGURACIÓN FIREBASE ---
@@ -619,25 +619,29 @@
 
     window.openDetails = async (id) => {
       // Implementación simplificada: buscar en el DOM o volver a pedir (usaremos volver a pedir para asegurar datos)
-      const docRef = await getDocs(query(collection(db, "payments"), where("__name__", "==", id)));
-      if (!docRef.empty) {
-         const data = docRef.docs[0].data();
-         const prod = PRODUCTS[data.product] || {name: data.product};
-         $('#modal-detail-content').innerHTML = `
-            <div class="text-center mb-4">
-               <div class="display-1 text-secondary">${prod.icon || '📦'}</div>
-               <h4 class="mt-2">${prod.name}</h4>
-               <span class="badge ${getStatusUI(data.status || 'pendiente').class} px-3 py-2 mt-2">${data.status}</span>
-            </div>
-            <div class="bg-light p-3 rounded border">
-               <div class="d-flex justify-content-between mb-2 border-bottom pb-2"><span>Farmacia:</span> <strong>${data.pharmacy}</strong></div>
-               <div class="d-flex justify-content-between mb-2 border-bottom pb-2"><span>Total:</span> <strong class="text-primary fs-5">${fmtMoney(data.totalAmount)}</strong></div>
-               <div class="d-flex justify-content-between mb-2"><span>Fecha:</span> <span>${fmtDate(data.date)}</span></div>
-               <div class="mt-3"><small class="text-muted d-block">Notas:</small> <p class="mb-0 small">${data.notes || "Sin notas"}</p></div>
-            </div>
-         `;
-         new bootstrap.Modal($('#detailsModal')).show();
+      const docSnap = await getDoc(doc(db, "payments", id));
+      if (!docSnap.exists()) {
+        showToast("No se encontró el pago solicitado.", "error");
+        return;
       }
+      const data = normalizeData(docSnap.data());
+      const status = data.status || "pendiente";
+      const totalAmount = Number(data.totalAmount ?? 0);
+      const prod = PRODUCTS[data.product] || {name: data.product};
+      $('#modal-detail-content').innerHTML = `
+        <div class="text-center mb-4">
+           <div class="display-1 text-secondary">${prod.icon || '📦'}</div>
+           <h4 class="mt-2">${prod.name}</h4>
+           <span class="badge ${getStatusUI(status).class} px-3 py-2 mt-2">${status}</span>
+        </div>
+        <div class="bg-light p-3 rounded border">
+           <div class="d-flex justify-content-between mb-2 border-bottom pb-2"><span>Farmacia:</span> <strong>${data.pharmacy}</strong></div>
+           <div class="d-flex justify-content-between mb-2 border-bottom pb-2"><span>Total:</span> <strong class="text-primary fs-5">${fmtMoney(totalAmount)}</strong></div>
+           <div class="d-flex justify-content-between mb-2"><span>Fecha:</span> <span>${fmtDate(data.date)}</span></div>
+           <div class="mt-3"><small class="text-muted d-block">Notas:</small> <p class="mb-0 small">${data.notes || "Sin notas"}</p></div>
+        </div>
+      `;
+      new bootstrap.Modal($('#detailsModal')).show();
     };
 
     // --- INICIALIZACIÓN ---


### PR DESCRIPTION
### Motivation
- Ensure direct document lookup for payment details instead of a query-by-name to simplify logic and improve performance.
- Surface a clear UI error when a payment document is missing to avoid silent failures.
- Normalize legacy/partial payment records before rendering to avoid runtime errors from missing fields.
- Clean up Firestore imports to include `getDoc` and remove the unused `where` import.

### Description
- Replaced the query-based lookup in `openDetails(id)` with `getDoc(doc(db, "payments", id))` for a direct document fetch.
- Added an explicit missing-document check that shows a toast via `showToast("No se encontró el pago solicitado.", "error")` and aborts rendering.
- Apply `normalizeData()` to the fetched document and guard `status` and `totalAmount` via `data.status || "pendiente"` and `Number(data.totalAmount ?? 0)` before populating the modal.
- Updated Firestore imports to add `getDoc` and removed the unused `where` import.

### Testing
- No automated tests were executed for this change.
- Changes were limited to `index.html` and committed successfully to the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bfac4d24832a835e82767eebf5a4)