### PR TITLE
Validate totals and compute fallback total in addItem

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,12 +582,27 @@
       btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Guardando...';
 
       try {
+        const quantity = Number($('#quantity').value);
+        const unitPrice = Number($('#unitPrice').value);
+        const totalValueInput = $('#total-value').value;
+
+        if (quantity <= 0) {
+          showToast("La cantidad debe ser mayor a 0", "error");
+          return;
+        }
+
+        if (unitPrice < 0) {
+          showToast("El precio unitario no puede ser negativo", "error");
+          return;
+        }
+
+        const totalAmount = totalValueInput ? Number(totalValueInput) : quantity * unitPrice;
         const data = {
           pharmacy: $('#pharmacy').value.trim(),
           product: $('#product').value,
-          quantity: Number($('#quantity').value),
-          unitPrice: Number($('#unitPrice').value),
-          totalAmount: Number($('#total-value').value),
+          quantity,
+          unitPrice,
+          totalAmount,
           date: new Date($('#date').value + "T00:00:00"),
           status: $('#status').value,
           notes: $('#notes').value


### PR DESCRIPTION
### Motivation
- Evitar el registro de pagos con valores inválidos verificando `quantity` y `unitPrice` antes de guardar.
- Permitir que el campo de total (`#total-value`) sea opcional y calcular `totalAmount` como `quantity * unitPrice` cuando esté vacío.
- Mantener la función de preview (`calculateTotal`) para la visualización en el formulario.

### Description
- En `index.html` dentro de `window.addItem` se parsean `quantity` y `unitPrice` desde el formulario antes de construir el objeto a guardar.
- Se valida que `quantity > 0` y `unitPrice >= 0`, mostrando un `showToast` de error y abortando si la validación falla.
- Si `#total-value` es falsy se calcula `totalAmount = quantity * unitPrice`; de lo contrario se usa el valor ingresado.
- El objeto `data` enviado a Firestore ahora incluye las variables `quantity`, `unitPrice` y `totalAmount` ya validadas.

### Testing
- No se ejecutaron tests automáticos durante este cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965c01b3bcc832a9783e4d4aa002cef)