### PR TITLE
Añadir regla Firestore explícita para cash_movements

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "crm-medicamentos"
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,16 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function canAccessPayments() {
+      return request.auth != null;
+    }
+
+    match /payments/{paymentId} {
+      allow read, write: if canAccessPayments();
+    }
+
+    match /cash_movements/{movementId} {
+      allow read, write: if canAccessPayments();
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Evitar el error `Missing or insufficient permissions` al consultar la colección `cash_movements` replicando la misma política de acceso que ya existe para `payments`.
- Homogeneizar el control de acceso entre `payments` y `cash_movements` para que ambas colecciones respeten el mismo requisito de autenticación.

### Description
- Agregué `firestore.rules` con la función helper `canAccessPayments()` que devuelve `request.auth != null` y aplica `allow read, write` a `/payments/{paymentId}` y `/cash_movements/{movementId}`.
- Añadí `firebase.json` apuntando las reglas a `firestore.rules` para el deploy de Firestore.
- Incluí `.firebaserc` con el proyecto por defecto `crm-medicamentos` para facilitar la publicación de reglas desde el entorno con Firebase CLI.

### Testing
- Intenté publicar las reglas con `npx firebase-tools deploy --only firestore:rules --project crm-medicamentos`, pero la operación falló en este entorno por bloqueo del registro npm (`403 Forbidden`).
- Serví la app localmente con `python3 -m http.server 8000` y la operación de servidor fue exitosa.
- Ejecución automática con Playwright contra `http://127.0.0.1:8000/index.html` para inspeccionar la consola del navegador no reprodujo el error de permisos en este entorno aislado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928eda56e4832a8f32b137f4c32082)