### PR TITLE
Prioriza cash_movements en dashboard y agrega migración histórica

### DIFF
--- a/docs/cash-movements-migration.md
+++ b/docs/cash-movements-migration.md
@@ -1,0 +1,31 @@
+# Migración de pagos históricos a `cash_movements`
+
+## Objetivo
+Convertir pagos históricos (`pagos_productos`) en movimientos de caja de tipo `egreso` para que el dashboard utilice `cash_movements` como fuente principal.
+
+## Script
+Archivo: `scripts/migrate-historical-payments-to-cash-movements.js`
+
+La rutina:
+- Recorre todos los documentos de `pagos_productos`.
+- Valida que el pago tenga valor total (`totalPago` / `totalAmount`).
+- Verifica si ya existe un movimiento `cash_movements` con `sourcePaymentId` del pago.
+- Crea movimiento `type: "egreso"` cuando haga falta.
+
+## Ejecución recomendada (manual, desde navegador)
+1. Abrir la aplicación CRM en un entorno con permisos de escritura sobre Firestore.
+2. Abrir DevTools > Console.
+3. Pegar el contenido de `scripts/migrate-historical-payments-to-cash-movements.js`.
+4. Ejecutar prueba sin escritura:
+   ```js
+   await migrateHistoricalPaymentsToCashMovements({ dryRun: true });
+   ```
+5. Revisar conteo (`created`, `skipped`, `total`).
+6. Ejecutar migración real:
+   ```js
+   await migrateHistoricalPaymentsToCashMovements({ dryRun: false });
+   ```
+
+## Validación post-migración
+- Confirmar que para el mes auditado existen `cash_movements` de tipo `egreso`.
+- Confirmar que el indicador del dashboard cambie a **Datos migrados** (sin fallback legacy).

--- a/index.html
+++ b/index.html
@@ -339,7 +339,10 @@
                     <div class="progress-glass">
                         <div id="budget-progress" class="progress-bar-glass" style="width: 0%"></div>
                     </div>
-                    <p class="text-white-50 mt-2 small text-end" id="kpi-egresos">Egresos: $0</p>
+                    <div class="d-flex align-items-center justify-content-between mt-2">
+                        <span id="kpi-data-source" class="badge fw-normal bg-warning text-dark">Datos mixtos</span>
+                        <p class="text-white-50 mb-0 small text-end" id="kpi-egresos">Egresos: $0</p>
+                    </div>
                 </div>
             </div>
 
@@ -632,6 +635,7 @@
             paymentReferences: [],
             budget: 500000,
             filters: { product: '', pharmacy: '', status: '', date: '' },
+            featureFlags: { allowLegacyCashFallback: true },
             loading: true
         };
 

--- a/scripts/migrate-historical-payments-to-cash-movements.js
+++ b/scripts/migrate-historical-payments-to-cash-movements.js
@@ -1,0 +1,67 @@
+/**
+ * Rutina de migración manual para ejecutar desde la consola del navegador
+ * con la app abierta (window.app ya inicializada y con acceso a Firestore).
+ *
+ * Uso:
+ * 1) Abrir CRM en el navegador.
+ * 2) Abrir DevTools > Console.
+ * 3) Pegar este archivo y ejecutar:
+ *      await migrateHistoricalPaymentsToCashMovements();
+ */
+async function migrateHistoricalPaymentsToCashMovements({ dryRun = true } = {}) {
+  const { collection, getDocs, addDoc, query, where, Timestamp, serverTimestamp } = await import(
+    "https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js"
+  );
+  const { db } = await import("./src/services/firebase.js");
+
+  const paymentsSnapshot = await getDocs(collection(db, "pagos_productos"));
+  let created = 0;
+  let skipped = 0;
+
+  for (const paymentDoc of paymentsSnapshot.docs) {
+    const payment = paymentDoc.data();
+    const paymentId = paymentDoc.id;
+    const amount = Number(payment.totalPago ?? payment.totalAmount ?? 0);
+
+    if (!amount) {
+      skipped += 1;
+      continue;
+    }
+
+    const existingMovementQuery = query(
+      collection(db, "cash_movements"),
+      where("sourcePaymentId", "==", paymentId),
+      where("type", "==", "egreso")
+    );
+
+    const existingMovementSnapshot = await getDocs(existingMovementQuery);
+    if (!existingMovementSnapshot.empty) {
+      skipped += 1;
+      continue;
+    }
+
+    const dateValue = payment.fecha || payment.date;
+    const date = typeof dateValue === "string" ? new Date(`${dateValue}T12:00:00`) : dateValue?.toDate?.() || new Date();
+
+    const movement = {
+      type: "egreso",
+      amount,
+      date: Timestamp.fromDate(date),
+      sourcePaymentId: paymentId,
+      source: "migration",
+      notes: "Generado por migración histórica desde pagos_productos",
+      createdAt: serverTimestamp()
+    };
+
+    if (!dryRun) {
+      await addDoc(collection(db, "cash_movements"), movement);
+    }
+
+    created += 1;
+  }
+
+  console.table({ dryRun, created, skipped, total: paymentsSnapshot.size });
+  return { dryRun, created, skipped, total: paymentsSnapshot.size };
+}
+
+window.migrateHistoricalPaymentsToCashMovements = migrateHistoricalPaymentsToCashMovements;

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -1,28 +1,61 @@
+const toDate = (value) => {
+  if (!value) return null;
+  if (value.toDate) return value.toDate();
+  if (value instanceof Date) return value;
+  if (typeof value === "string") {
+    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T12:00:00` : value;
+    const parsed = new Date(normalized);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+  return null;
+};
+
+const isInSelectedMonth = (dateValue, selectedMonth) => {
+  if (!selectedMonth) return true;
+
+  const date = toDate(dateValue);
+  if (!date) return false;
+
+  const [year, month] = selectedMonth.split("-").map(Number);
+  return date.getFullYear() === year && date.getMonth() + 1 === month;
+};
+
 export const updateDashboard = (state, utils) => {
   const stats = { descongel: 0, multi400: 0, multi800: 0, pending: 0, egresos: 0 };
+  const selectedMonth = state.filters?.date || "";
+  const filteredPayments = state.payments.filter((payment) => isInSelectedMonth(payment.date, selectedMonth));
+  const filteredMovements = state.movements.filter((movement) => isInSelectedMonth(movement.date, selectedMonth));
 
-  state.payments.forEach((p) => {
+  filteredPayments.forEach((p) => {
     if (p.product === "descongel") stats.descongel += p.quantity;
     if (p.product === "multidol400") stats.multi400 += p.quantity;
     if (p.product === "multidol800") stats.multi800 += p.quantity;
     if (p.status === "pendiente") stats.pending += 1;
-    stats.egresos += p.totalAmount || 0;
   });
 
-  const movementEgresos = state.movements
+  const movementEgresos = filteredMovements
     .filter((m) => m.type === "egreso")
     .reduce((acc, m) => acc + (m.amount || 0), 0);
 
-  stats.egresos += movementEgresos;
-
-  const reintegros = state.movements
+  const movementReintegros = filteredMovements
     .filter((m) => m.type === "reintegro")
     .reduce((acc, m) => acc + (m.amount || 0), 0);
 
-  const legacyReintegros = state.payments.reduce((acc, p) => acc + (p.reimbursedAmount || 0), 0);
-  const totalReintegros = reintegros + legacyReintegros;
+  const legacyEgresos = filteredPayments.reduce((acc, p) => acc + (p.totalAmount || 0), 0);
+  const legacyReintegros = filteredPayments.reduce((acc, p) => acc + (p.reimbursedAmount || 0), 0);
+
+  const hasMovementEgresos = filteredMovements.some((m) => m.type === "egreso");
+  const hasMovementReintegros = filteredMovements.some((m) => m.type === "reintegro");
+  const allowLegacyFallback = Boolean(state.featureFlags?.allowLegacyCashFallback);
+
+  const usingLegacyEgresos = !hasMovementEgresos && allowLegacyFallback;
+  const usingLegacyReintegros = !hasMovementReintegros && allowLegacyFallback;
+
+  stats.egresos = usingLegacyEgresos ? legacyEgresos : movementEgresos;
+  const totalReintegros = usingLegacyReintegros ? legacyReintegros : movementReintegros;
+
   const available = state.budget + totalReintegros - stats.egresos;
-  const usagePercent = (stats.egresos / state.budget) * 100;
+  const usagePercent = state.budget > 0 ? (stats.egresos / state.budget) * 100 : 0;
 
   document.getElementById("stat-descongel").textContent = stats.descongel;
   document.getElementById("stat-multi400").textContent = stats.multi400;
@@ -31,6 +64,13 @@ export const updateDashboard = (state, utils) => {
 
   document.getElementById("kpi-available").textContent = utils.fmtMoney(available);
   document.getElementById("kpi-egresos").textContent = `Egresos: ${utils.fmtMoney(stats.egresos)}`;
+
+  const migrationBadge = document.getElementById("kpi-data-source");
+  if (migrationBadge) {
+    const isMixedMode = usingLegacyEgresos || usingLegacyReintegros;
+    migrationBadge.textContent = isMixedMode ? "Datos mixtos" : "Datos migrados";
+    migrationBadge.className = `badge fw-normal ${isMixedMode ? "bg-warning text-dark" : "bg-success-subtle text-success"}`;
+  }
 
   const percentText = document.getElementById("kpi-percentage");
   const progressBar = document.getElementById("budget-progress");
@@ -45,5 +85,6 @@ export const updateDashboard = (state, utils) => {
     progressBar.style.background = "var(--warning)";
   } else {
     progressBar.style.background = "rgba(255, 255, 255, 0.9)";
+    percentText.classList.remove("text-warning");
   }
 };


### PR DESCRIPTION
### Motivation
- Hacer de `cash_movements` la fuente principal para egresos y reintegros para soportar una migración de datos limpia.
- Calcular métricas del dashboard usando únicamente movimientos disponibles dentro del rango temporal (mes seleccionado).
- Mantener el cálculo legacy como fallback controlado por un feature flag para permitir una transición gradual.
- Proveer una rutina y documentación para generar los movimientos faltantes a partir de pagos históricos y mostrar un indicador visual del estado de la migración.

### Description
- Actualiza `src/ui/dashboard.js` para normalizar fechas, filtrar `payments` y `movements` por mes seleccionado, priorizar `cash_movements` para `egresos`/`reintegros` y usar legacy solo si `state.featureFlags.allowLegacyCashFallback` está habilitado, además de exponer el badge `kpi-data-source` con los textos “Datos migrados” / “Datos mixtos”.
- Modifica `index.html` para incluir el badge visual `kpi-data-source` en la card de presupuesto y añadir `featureFlags: { allowLegacyCashFallback: true }` en el estado inicial.
- Añade `scripts/migrate-historical-payments-to-cash-movements.js`, una rutina pensada para ejecución manual en consola del navegador con `dryRun` por defecto, que crea movimientos `egreso` deduplicados (usa `sourcePaymentId`) a partir de `pagos_productos`.
- Agrega `docs/cash-movements-migration.md` con instrucciones y pasos recomendados para ejecutar y validar la migración histórica.

### Testing
- Ejecutado `node --check src/ui/dashboard.js && node --check scripts/migrate-historical-payments-to-cash-movements.js`, y las comprobaciones de sintaxis JS completaron correctamente.
- Levantado servidor estático (`python3 -m http.server 4173`) y se intentó capturar una captura con Playwright, pero la ejecución del navegador falló en este contenedor (Chromium terminó con SIGSEGV) y no se generó la screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e1e3bb6c832ab70ae86f9fcaf4d0)