### PR TITLE
Reemplazar selector múltiple por checkboxes con buscador y acciones rápidas en modal Nuevo Pago

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,42 @@
             box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
         }
 
+
+        .pay-refs-panel {
+            border: 1px solid #e2e8f0;
+            border-radius: 0.75rem;
+            padding: 0.75rem;
+            background: #fff;
+        }
+
+        .pay-refs-list {
+            max-height: 180px;
+            overflow-y: auto;
+            border: 1px solid #e2e8f0;
+            border-radius: 0.5rem;
+            padding: 0.5rem;
+            background: #f8fafc;
+        }
+
+        .pay-ref-item {
+            min-height: 44px;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .pay-ref-item .form-check-input {
+            width: 1.1rem;
+            height: 1.1rem;
+        }
+
+        #pay-selected-refs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.35rem;
+            min-height: 30px;
+        }
+
         /* --- TABLA --- */
         .table-container {
             background: white;
@@ -516,16 +552,28 @@
                         </div>
 
                         <div class="mb-3">
-                            <div class="d-flex align-items-center justify-content-between mb-2">
+                            <div class="d-flex align-items-center justify-content-between mb-2 gap-2 flex-wrap">
                                 <label class="form-label small fw-bold text-uppercase text-muted mb-0">Referencias de Pago</label>
                                 <button type="button" class="btn btn-sm btn-outline-primary" id="btn-new-reference">
                                     <i class="fa-solid fa-plus me-1"></i>Nueva referencia
                                 </button>
                             </div>
-                            <select class="form-select" id="pay-refs" multiple size="4"></select>
-                            <small class="text-muted">Puedes seleccionar varias referencias de pago.</small>
+                            <div class="pay-refs-panel">
+                                <input type="search" class="form-control form-control-sm mb-2" id="pay-refs-search" placeholder="Buscar referencia..." aria-label="Buscar referencia de pago">
+                                <div class="d-flex gap-2 mb-2 flex-wrap">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-select-all-refs">Seleccionar todas</button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="btn-clear-refs">Limpiar selección</button>
+                                </div>
+                                <div class="pay-refs-list" id="pay-refs"></div>
+                            </div>
+                            <small class="text-muted d-block mt-1">Selección táctil compatible en móvil, sin teclas Ctrl/Cmd.</small>
                         </div>
-                        
+
+                        <div class="mb-3">
+                            <label class="form-label small fw-bold text-uppercase text-muted">Seleccionadas</label>
+                            <div id="pay-selected-refs" class="border rounded p-2 bg-light"></div>
+                        </div>
+
                         <div class="mb-0">
                             <label class="form-label small fw-bold text-uppercase text-muted">Notas Adicionales</label>
                             <textarea class="form-control" id="pay-notes" rows="2" placeholder="Detalles opcionales..."></textarea>
@@ -621,6 +669,7 @@
         import { updateDashboard } from "./src/ui/dashboard.js";
         import {
             renderPaymentReferencesSelector,
+            setupPaymentReferencesControls,
             handleCreatePaymentReference,
             handleSavePayment,
             handleSaveReintegro,
@@ -730,6 +779,7 @@
             updateDashboard: () => updateDashboard(state, utils),
             updateFiltersUI: () => updateFiltersUI(state.payments),
             renderPaymentReferencesSelector: (pharmacy) => renderPaymentReferencesSelector(pharmacy, state, utils),
+            setupPaymentReferencesControls: () => setupPaymentReferencesControls({ state, utils }),
 
             setupEventListeners: () => {
                 ['filter-product', 'filter-pharmacy', 'filter-status', 'filter-date'].forEach((id) => {
@@ -753,6 +803,7 @@
                 document.getElementById('pay-price').addEventListener('input', calcTotal);
                 document.getElementById('pay-pharmacy').addEventListener('input', (e) => app.renderPaymentReferencesSelector(e.target.value));
                 document.getElementById('btn-new-reference').addEventListener('click', app.handleCreatePaymentReference);
+                app.setupPaymentReferencesControls();
             },
 
             handleCreatePaymentReference: () => handleCreatePaymentReference({ db, state, utils }),

--- a/src/ui/modals.js
+++ b/src/ui/modals.js
@@ -40,18 +40,103 @@ const setFieldError = (fieldId, message) => {
 };
 
 export const renderPaymentReferencesSelector = (pharmacy, state, utils) => {
-  const selector = document.getElementById("pay-refs");
-  const selectedValues = Array.from(selector.selectedOptions || []).map((option) => option.value);
-  const availableReferences = getAvailablePaymentReferencesByPharmacy(state.paymentReferences, pharmacy, utils.normalizeText);
+  const listContainer = document.getElementById("pay-refs");
+  if (!listContainer) return;
 
-  selector.innerHTML = "";
+  const selectedValues = Array.from(document.querySelectorAll(".pay-ref-checkbox:checked")).map((checkbox) => checkbox.value);
+  const availableReferences = getAvailablePaymentReferencesByPharmacy(state.paymentReferences, pharmacy, utils.normalizeText);
+  const currentFilter = (document.getElementById("pay-refs-search")?.value || "").toLowerCase().trim();
+
+  listContainer.innerHTML = "";
+
+  if (availableReferences.length === 0) {
+    listContainer.innerHTML = '<small class="text-muted fst-italic">No hay referencias disponibles para esta farmacia.</small>';
+    updateSelectedReferencesChips();
+    return;
+  }
+
   availableReferences.forEach((item) => {
-    const option = document.createElement("option");
-    option.value = item.reference;
-    option.textContent = item.reference;
-    option.selected = selectedValues.includes(item.reference);
-    selector.appendChild(option);
+    const wrapper = document.createElement("div");
+    wrapper.className = "form-check pay-ref-item rounded px-2 py-1";
+    wrapper.dataset.reference = item.reference.toLowerCase();
+
+    if (currentFilter && !wrapper.dataset.reference.includes(currentFilter)) {
+      wrapper.classList.add("d-none");
+    }
+
+    const input = document.createElement("input");
+    input.className = "form-check-input pay-ref-checkbox";
+    input.type = "checkbox";
+    input.id = `pay-ref-${item.reference.replace(/[^a-z0-9]/gi, "-").toLowerCase()}`;
+    input.value = item.reference;
+    input.checked = selectedValues.includes(item.reference);
+
+    const label = document.createElement("label");
+    label.className = "form-check-label w-100 py-1";
+    label.htmlFor = input.id;
+    label.textContent = item.reference;
+
+    wrapper.appendChild(input);
+    wrapper.appendChild(label);
+    listContainer.appendChild(wrapper);
   });
+
+  bindPaymentReferenceCheckboxes();
+  updateSelectedReferencesChips();
+};
+
+const getSelectedPaymentReferences = () =>
+  Array.from(document.querySelectorAll(".pay-ref-checkbox:checked")).map((checkbox) => checkbox.value);
+
+const updateSelectedReferencesChips = () => {
+  const chipsContainer = document.getElementById("pay-selected-refs");
+  if (!chipsContainer) return;
+
+  const selectedReferences = getSelectedPaymentReferences();
+  if (selectedReferences.length === 0) {
+    chipsContainer.innerHTML = '<span class="text-muted small fst-italic">Sin referencias seleccionadas.</span>';
+    return;
+  }
+
+  chipsContainer.innerHTML = selectedReferences
+    .map((reference) => `<span class="badge rounded-pill text-bg-primary">${reference}</span>`)
+    .join("");
+};
+
+const bindPaymentReferenceCheckboxes = () => {
+  document.querySelectorAll(".pay-ref-checkbox").forEach((checkbox) => {
+    checkbox.addEventListener("change", updateSelectedReferencesChips);
+  });
+};
+
+export const setupPaymentReferencesControls = ({ state, utils }) => {
+  const searchInput = document.getElementById("pay-refs-search");
+  const selectAllButton = document.getElementById("btn-select-all-refs");
+  const clearButton = document.getElementById("btn-clear-refs");
+
+  searchInput?.addEventListener("input", () => {
+    const filterValue = searchInput.value.toLowerCase().trim();
+    document.querySelectorAll(".pay-ref-item").forEach((item) => {
+      const matches = item.dataset.reference.includes(filterValue);
+      item.classList.toggle("d-none", !matches);
+    });
+  });
+
+  selectAllButton?.addEventListener("click", () => {
+    document.querySelectorAll(".pay-ref-item:not(.d-none) .pay-ref-checkbox").forEach((checkbox) => {
+      checkbox.checked = true;
+    });
+    updateSelectedReferencesChips();
+  });
+
+  clearButton?.addEventListener("click", () => {
+    document.querySelectorAll(".pay-ref-checkbox").forEach((checkbox) => {
+      checkbox.checked = false;
+    });
+    updateSelectedReferencesChips();
+  });
+
+  renderPaymentReferencesSelector(document.getElementById("pay-pharmacy")?.value || "", state, utils);
 };
 
 export const handleCreatePaymentReference = async ({ db, state, utils }) => {
@@ -110,7 +195,7 @@ export const handleSavePayment = async ({ db, state, utils }) => {
   const price = parseFloat(document.getElementById("pay-price").value);
   const status = document.getElementById("pay-status").value;
   const notes = document.getElementById("pay-notes").value;
-  const refs = Array.from(document.getElementById("pay-refs").selectedOptions).map((option) => option.value);
+  const refs = getSelectedPaymentReferences();
 
   const normalizedPharmacy = normalizeWhitespace(pharmacy);
   const normalizedRefs = [...new Set(refs.map((ref) => ref.trim()).filter((ref) => ref))];
@@ -176,6 +261,7 @@ export const handleSavePayment = async ({ db, state, utils }) => {
     document.getElementById("form-payment").reset();
     document.getElementById("pay-date").valueAsDate = new Date();
     document.getElementById("pay-preview-alert").classList.add("d-none");
+    document.getElementById("pay-refs-search").value = "";
     renderPaymentReferencesSelector("", state, utils);
 
     utils.showToast("Pago registrado exitosamente");


### PR DESCRIPTION
### Motivation
- Mejorar la usabilidad del control de referencias de pago sustituyendo el `<select multiple>` por controles táctiles apropiados para móvil. 
- Mostrar las referencias seleccionadas como chips para revisarlas antes de guardar. 
- Añadir acciones rápidas para facilitar la selección masiva y el borrado sin depender de teclas Ctrl/Cmd. 
- Mantener compatibilidad con el payload actual `paymentReferences: string[]` al guardar.

### Description
- Reemplacé el `<select multiple id="pay-refs">` por una lista renderizada de checkboxes con buscador y contenedor scrollable, y añadí estilos (`index.html`).
- Implementé `renderPaymentReferencesSelector` para generar checkboxes por farmacia y conservar la selección visible, y añadí funciones auxiliares `getSelectedPaymentReferences`, `updateSelectedReferencesChips`, `bindPaymentReferenceCheckboxes` y `setupPaymentReferencesControls` en `src/ui/modals.js`.
- Añadí botones de acción rápida `Seleccionar todas` y `Limpiar selección`, un campo de búsqueda `pay-refs-search` y un contenedor de chips `pay-selected-refs` que se actualiza en tiempo real.
- Mantengo la lógica de guardado para producir `paymentReferences: string[]` normalizado (se lee desde los checkboxes marcados antes de construir `newPayment`).

### Testing
- Ejecuté `node --check src/ui/modals.js` y pasó correctamente.
- Ejecuté un script automatizado con Playwright para abrir la página, abrir el modal y capturar una pantalla; el primer intento falló por timeout y el segundo intento automatizado terminó con éxito y generó la captura del modal.
- Levanté un servidor local (`python -m http.server`) como dependencia del test de UI y la instancia respondió correctamente durante la validación.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e2c8be4c832abdda152fbae14a01)