### PR TITLE
Refactor responsive table to horizontal scroll with sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,16 @@
             border-radius: var(--radius-lg);
             box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05);
             border: 1px solid #e2e8f0;
-            overflow: hidden;
+            /* IMPORTANTE: reemplaza tarjetas móviles por scroll horizontal fluido. */
+            overflow-x: auto;
+            overflow-y: visible;
+            -webkit-overflow-scrolling: touch;
+        }
+
+        .table {
+            /* IMPORTANTE: conserva columnas estables y evita colapsos en Android. */
+            table-layout: fixed;
+            min-width: 940px;
         }
 
         .table thead th {
@@ -212,6 +221,10 @@
             letter-spacing: 0.05em;
             padding: 1rem 1.5rem;
             border-bottom: 1px solid #e2e8f0;
+            /* IMPORTANTE: encabezado fijo para mejorar la lectura en scroll vertical. */
+            position: sticky;
+            top: 0;
+            z-index: 3;
         }
 
         .table tbody td {
@@ -269,32 +282,19 @@
             background: var(--secondary);
         }
 
-        /* --- RESPONSIVE TABLE (Mobile Cards) --- */
+        /* --- RESPONSIVE TABLE (Mobile Scroll) --- */
         @media (max-width: 768px) {
-            .table thead { display: none; }
-            .table, .table tbody, .table tr, .table td { display: block; width: 100%; }
-            .table tr {
-                margin-bottom: 1rem;
-                border: 1px solid #e2e8f0;
-                border-radius: 12px;
-                background: white;
-                padding: 1rem;
-            }
-            .table td {
-                padding: 0.5rem 0;
-                text-align: right;
-                border: none;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-            }
-            .table td::before {
-                content: attr(data-label);
-                font-weight: 600;
-                color: #64748b;
-                font-size: 0.8rem;
-                text-transform: uppercase;
-            }
+            /* IMPORTANTE: se conserva <thead>; data-label queda opcional para fallback. */
+            .table td[data-label]::before { content: none; }
+            /* IMPORTANTE: refuerza la alineación semántica por tipo de dato. */
+            .table tbody td:nth-child(1),
+            .table tbody td:nth-child(2),
+            .table tbody td:nth-child(3) { text-align: left; }
+            .table tbody td:nth-child(4),
+            .table tbody td:nth-child(7) { text-align: center; }
+            .table tbody td:nth-child(5),
+            .table tbody td:nth-child(6),
+            .table tbody td:nth-child(8) { text-align: right; }
             .fab-button { bottom: 1.5rem; right: 1.5rem; width: 50px; height: 50px; font-size: 1.25rem; }
         }
 


### PR DESCRIPTION
### Motivation
- Mantener la tabla nativa en móvil en lugar de transformarla a tarjetas para conservar la semántica y accesibilidad del `<thead>`.
- Mejorar la usabilidad en Android/iOS evitando que las columnas colapsen y permitiendo lectura fluida al hacer scroll.
- Hacer opcional el uso de `data-label` para que los scripts que generan filas sigan funcionando sin requerir transformaciones CSS.

### Description
- Reemplacé la transformación móvil de tipo "cards" por un contenedor con scroll horizontal en `.table-container` usando `overflow-x: auto` y `-webkit-overflow-scrolling: touch` y añadí comentarios `/* IMPORTANTE: ... */` en líneas relevantes.
- Añadí `table { table-layout: fixed; min-width: 940px; }` para mantener la estructura de columnas y evitar colapsos en pantallas pequeñas.
- Hice el encabezado visible y sticky aplicando `thead th { position: sticky; top: 0; z-index: 3; }` para lectura continua mientras se hace scroll.
- Ajusté la regla móvil para que `data-label` quede opcional y reforcé la alineación semántica por columna en el breakpoint (`text-left` para textos, `text-right` para montos/acciones y `text-center` para cantidad/estado).

### Testing
- Ejecuté `git diff --check` sin reportar errores de whitespace o advertencias.
- Verifiqué el estado de los cambios con `git status --short` mostrando el archivo modificado (`index.html`).
- Se validó localmente que el archivo `index.html` contiene los nuevos comentarios y reglas CSS solicitadas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b7a1c350832a837f5af26a5a64b6)