### PR TITLE
Tabla móvil: mostrar columnas esenciales y mover secundarias a expansión por fila

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,6 +226,54 @@
             background-color: #f8fafc;
         }
 
+        /* Importante: clases de prioridad para ocultar/mostrar columnas sin romper semántica de <table>. */
+        .col-priority-essential { display: table-cell; }
+        .col-priority-secondary { display: table-cell; }
+
+        .row-expand-details {
+            position: relative;
+            display: inline-block;
+        }
+
+        .row-expand-details summary {
+            list-style: none;
+            cursor: pointer;
+        }
+
+        .row-expand-details summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .row-expand-panel {
+            position: absolute;
+            right: 0;
+            top: calc(100% + 0.35rem);
+            min-width: 240px;
+            z-index: 10;
+            background: #fff;
+            border: 1px solid #e2e8f0;
+            border-radius: 0.75rem;
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+            padding: 0.75rem;
+        }
+
+        .row-expand-line {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.75rem;
+            font-size: 0.85rem;
+            padding: 0.2rem 0;
+        }
+
+        .row-expand-line::before {
+            content: attr(data-label);
+            color: #64748b;
+            font-weight: 600;
+            font-size: 0.72rem;
+            text-transform: uppercase;
+        }
+
         /* Badges de Productos */
         .badge-product {
             padding: 0.35em 0.8em;
@@ -269,31 +317,28 @@
             background: var(--secondary);
         }
 
-        /* --- RESPONSIVE TABLE (Mobile Cards) --- */
+        /* --- RESPONSIVE TABLE (prioridad por columnas) --- */
         @media (max-width: 768px) {
-            .table thead { display: none; }
-            .table, .table tbody, .table tr, .table td { display: block; width: 100%; }
-            .table tr {
-                margin-bottom: 1rem;
-                border: 1px solid #e2e8f0;
-                border-radius: 12px;
-                background: white;
-                padding: 1rem;
+            /* Importante: sólo se ocultan columnas secundarias en móvil. */
+            .table th.col-priority-secondary,
+            .table td.col-priority-secondary {
+                display: none;
             }
-            .table td {
-                padding: 0.5rem 0;
-                text-align: right;
-                border: none;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
+            .table th.col-priority-essential,
+            .table td.col-priority-essential {
+                display: table-cell;
             }
-            .table td::before {
-                content: attr(data-label);
-                font-weight: 600;
-                color: #64748b;
-                font-size: 0.8rem;
-                text-transform: uppercase;
+            .table thead th,
+            .table tbody td {
+                padding: 0.75rem 0.6rem;
+                font-size: 0.82rem;
+                white-space: nowrap;
+            }
+            .row-expand-panel {
+                right: 0;
+                left: auto;
+                min-width: 210px;
+                max-width: 82vw;
             }
             .fab-button { bottom: 1.5rem; right: 1.5rem; width: 50px; height: 50px; font-size: 1.25rem; }
         }
@@ -463,14 +508,11 @@
             <table class="table mb-0">
                 <thead>
                     <tr>
-                        <th class="ps-4">Fecha</th>
-                        <th>Farmacia</th>
-                        <th>Producto</th>
-                        <th class="text-center">Cant.</th>
-                        <th class="text-end">Unitario</th>
-                        <th class="text-end">Total</th>
-                        <th class="text-center">Estado</th>
-                        <th class="text-end pe-4">Acciones</th>
+                        <th class="ps-4 col-priority-essential">Fecha</th>
+                        <th class="col-priority-essential">Farmacia</th>
+                        <th class="text-end col-priority-essential">Total</th>
+                        <th class="text-center col-priority-essential">Estado</th>
+                        <th class="text-end pe-4 col-priority-essential">Acciones</th>
                     </tr>
                 </thead>
                 <tbody id="payments-table-body">

--- a/src/ui/table.js
+++ b/src/ui/table.js
@@ -20,30 +20,45 @@ export const renderTable = (data, { utils, getProductConfig }) => {
     row.style.animationDelay = `${delay}ms`;
 
     row.innerHTML = `
-      <td class="fw-medium text-muted" data-label="Fecha">${utils.fmtDate(item.date)}</td>
-      <td class="fw-bold text-dark" data-label="Farmacia">${item.pharmacy}</td>
-      <td data-label="Producto">
-          <span class="badge-product ${prodConfig.badge}">
-              <i class="fa-solid ${prodConfig.icon}"></i> ${prodConfig.label}
-          </span>
-      </td>
-      <td class="text-center fw-medium" data-label="Cant.">${item.quantity}</td>
-      <td class="text-end text-muted font-monospace" data-label="Unitario">${utils.fmtMoney(item.unitPrice)}</td>
-      <td class="text-end fw-bold text-primary font-monospace" data-label="Total">${utils.fmtMoney(item.totalAmount)}</td>
-      <td class="text-center" data-label="Estado">
+      <td class="fw-medium text-muted col-priority-essential" data-label="Fecha">${utils.fmtDate(item.date)}</td>
+      <td class="fw-bold text-dark col-priority-essential" data-label="Farmacia">${item.pharmacy}</td>
+      <td class="text-end fw-bold text-primary font-monospace col-priority-essential" data-label="Total">${utils.fmtMoney(item.totalAmount)}</td>
+      <td class="text-center col-priority-essential" data-label="Estado">
           <button onclick="app.toggleStatus('${item.id}', '${item.status}')"
               class="btn btn-sm border-0 badge-status-${item.status} fw-bold text-uppercase px-3 py-1 rounded-pill" style="font-size: 0.7rem; letter-spacing: 0.5px;">
               ${isProcessed ? '<i class="fa-solid fa-check me-1"></i>Procesado' : '<i class="fa-regular fa-clock me-1"></i>Pendiente'}
           </button>
       </td>
-      <td class="text-end pe-md-4" data-label="Acciones">
-          <div class="d-flex justify-content-end gap-2">
+      <td class="text-end pe-md-4 col-priority-essential" data-label="Acciones">
+          <div class="d-flex justify-content-end gap-2 align-items-center">
+              <!-- Importante: el botón de detalles siempre queda disponible para trazabilidad en móvil. -->
               <button onclick="app.openDetails('${item.id}')" class="btn btn-sm btn-light text-primary hover-shadow">
                   <i class="fa-regular fa-eye"></i>
               </button>
-              <button onclick="app.deleteItem('${item.id}')" class="btn btn-sm btn-light text-danger hover-shadow">
-                  <i class="fa-regular fa-trash-can"></i>
-              </button>
+              <!-- Importante: datos/acciones secundarios se mueven al patrón de expansión por fila. -->
+              <details class="row-expand-details">
+                  <summary class="btn btn-sm btn-light text-secondary hover-shadow" aria-label="Ver más opciones y datos de la fila">
+                      <i class="fa-solid fa-ellipsis"></i>
+                  </summary>
+                  <div class="row-expand-panel text-start">
+                      <div class="row-expand-line col-priority-secondary" data-label="Producto">
+                          <span class="badge-product ${prodConfig.badge}">
+                              <i class="fa-solid ${prodConfig.icon}"></i> ${prodConfig.label}
+                          </span>
+                      </div>
+                      <div class="row-expand-line col-priority-secondary" data-label="Cantidad">
+                          <span class="fw-medium">${item.quantity}</span>
+                      </div>
+                      <div class="row-expand-line col-priority-secondary" data-label="Unitario">
+                          <span class="text-muted font-monospace">${utils.fmtMoney(item.unitPrice)}</span>
+                      </div>
+                      <div class="pt-2 border-top mt-2 col-priority-secondary">
+                          <button onclick="app.deleteItem('${item.id}')" class="btn btn-sm btn-light text-danger hover-shadow w-100">
+                              <i class="fa-regular fa-trash-can me-1"></i> Eliminar
+                          </button>
+                      </div>
+                  </div>
+              </details>
           </div>
       </td>
     `;


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad en móvil mostrando sólo las columnas esenciales (`Fecha`, `Farmacia`, `Total`, `Estado`) en la fila principal.
- Evitar romper la semántica de `<table>` mientras se ocultan columnas secundarias en pantallas pequeñas. 
- Mantener siempre disponible el botón de detalles para no perder trazabilidad de cada fila.

### Description
- Cambiado `renderTable` en `src/ui/table.js` para que la fila principal incluya sólo las columnas esenciales y las celdas tengan la clase de prioridad `col-priority-essential`.
- Movidos los datos y acciones secundarios (`Producto`, `Cantidad`, `Unitario`, `Eliminar`) a una expansión por fila usando `<details>/<summary>` con clases `row-expand-*` para el menú contextual/«ver más». 
- Añadidas clases de prioridad (`col-priority-essential`, `col-priority-secondary`) y reglas responsive en `index.html` que ocultan las columnas secundarias en `@media (max-width: 768px)` sin convertir la tabla a bloques. 
- Insertados comentarios importantes en las líneas de código cerca de los cambios críticos para marcar la trazabilidad y el comportamiento esperado del botón de detalles.

### Testing
- Ejecutado `node --check src/ui/table.js` y la verificación de sintaxis JS completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b816cfb4832aa2d0b454bc374511)