### PR TITLE
Mostrar valor monetario para registros pendientes en dashboard

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,0 +1,7 @@
+127.0.0.1 - - [26/Jun/2026 14:20:36] "GET /index.html HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/services/payments.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/ui/table.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/ui/dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/services/firebase.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/ui/modals.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/services/references.js HTTP/1.1" 200 -

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -30,7 +30,7 @@ export const updateDashboard = (state, utils) => {
     if (p.product === "descongel") stats.descongel += p.quantity;
     if (p.product === "multidol400") stats.multi400 += p.quantity;
     if (p.product === "multidol800") stats.multi800 += p.quantity;
-    if (p.status === "pendiente") stats.pending += 1;
+    if (p.status === "pendiente") stats.pending += (p.totalAmount || 0);
   });
 
   const movementEgresos = filteredMovements
@@ -60,7 +60,7 @@ export const updateDashboard = (state, utils) => {
   document.getElementById("stat-descongel").textContent = stats.descongel;
   document.getElementById("stat-multi400").textContent = stats.multi400;
   document.getElementById("stat-multi800").textContent = stats.multi800;
-  document.getElementById("stat-pending").textContent = stats.pending;
+  document.getElementById("stat-pending").textContent = utils.fmtMoney(stats.pending);
 
   document.getElementById("kpi-available").textContent = utils.fmtMoney(available);
   document.getElementById("kpi-egresos").textContent = `Egresos: ${utils.fmtMoney(stats.egresos)}`;


### PR DESCRIPTION
Se modificó la lógica del dashboard en `src/ui/dashboard.js` para sumar el valor monetario (`totalAmount`) de los registros pendientes en lugar de contar la cantidad. El valor se formatea usando la función `utils.fmtMoney` para mostrarlo como dinero en la interfaz (Pesos Colombianos).

---
*PR created automatically by Jules for task [6081268888784362604](https://jules.google.com/task/6081268888784362604) started by @EdwDevs*