### PR TITLE
feat(ui): display pending sum as money amount in main KPI when filtered

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,7 +531,7 @@
                 <div class="budget-card h-100">
                     <div class="d-flex justify-content-between align-items-start mb-4">
                         <div>
-                            <p class="mb-1 text-white-50 fw-medium small text-uppercase ls-1">Fondo Disponible</p>
+                            <p class="mb-1 text-white-50 fw-medium small text-uppercase ls-1" id="kpi-available-title">Fondo Disponible</p>
                             <h2 class="display-5 fw-bold mb-0" id="kpi-available">$0</h2>
                         </div>
                         <div class="bg-white bg-opacity-25 p-2 rounded-3">

--- a/server.log
+++ b/server.log
@@ -5,3 +5,10 @@
 127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/services/firebase.js HTTP/1.1" 200 -
 127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/ui/modals.js HTTP/1.1" 200 -
 127.0.0.1 - - [26/Jun/2026 14:20:37] "GET /src/services/references.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /index.html HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/services/firebase.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/services/payments.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/ui/modals.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/ui/dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/ui/table.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/services/references.js HTTP/1.1" 200 -

--- a/src/ui/dashboard.js
+++ b/src/ui/dashboard.js
@@ -23,7 +23,19 @@ const isInSelectedMonth = (dateValue, selectedMonth) => {
 export const updateDashboard = (state, utils) => {
   const stats = { descongel: 0, multi400: 0, multi800: 0, pending: 0, egresos: 0 };
   const selectedMonth = state.filters?.date || "";
+  const isPendingFilter = state.filters?.status === "pendiente";
+
+  const matchesFilters = (payment) => {
+    let match = isInSelectedMonth(payment.date, selectedMonth);
+    if (state.filters?.status) match = match && payment.status === state.filters.status;
+    if (state.filters?.product) match = match && payment.product === state.filters.product;
+    if (state.filters?.pharmacy) match = match && payment.pharmacy === state.filters.pharmacy;
+    return match;
+  };
+
   const filteredPayments = state.payments.filter((payment) => isInSelectedMonth(payment.date, selectedMonth));
+  const fullyFilteredPayments = state.payments.filter(matchesFilters);
+
   const filteredMovements = state.movements.filter((movement) => isInSelectedMonth(movement.date, selectedMonth));
 
   filteredPayments.forEach((p) => {
@@ -57,12 +69,27 @@ export const updateDashboard = (state, utils) => {
   const available = state.budget + totalReintegros - stats.egresos;
   const usagePercent = state.budget > 0 ? (stats.egresos / state.budget) * 100 : 0;
 
+  let currentPendingAmount = 0;
+  if (isPendingFilter) {
+    currentPendingAmount = fullyFilteredPayments.reduce((acc, p) => acc + (p.totalAmount || 0), 0);
+  }
+
   document.getElementById("stat-descongel").textContent = stats.descongel;
   document.getElementById("stat-multi400").textContent = stats.multi400;
   document.getElementById("stat-multi800").textContent = stats.multi800;
   document.getElementById("stat-pending").textContent = utils.fmtMoney(stats.pending);
 
-  document.getElementById("kpi-available").textContent = utils.fmtMoney(available);
+  const kpiAvailableEl = document.getElementById("kpi-available");
+  const kpiAvailableTitleEl = document.getElementById("kpi-available-title");
+
+  if (isPendingFilter) {
+    kpiAvailableEl.textContent = utils.fmtMoney(currentPendingAmount);
+    if (kpiAvailableTitleEl) kpiAvailableTitleEl.textContent = "TOTAL PENDIENTE";
+  } else {
+    kpiAvailableEl.textContent = utils.fmtMoney(available);
+    if (kpiAvailableTitleEl) kpiAvailableTitleEl.textContent = "Fondo Disponible";
+  }
+
   document.getElementById("kpi-egresos").textContent = `Egresos: ${utils.fmtMoney(stats.egresos)}`;
 
   const migrationBadge = document.getElementById("kpi-data-source");


### PR DESCRIPTION
Update the dashboard logic to dynamically calculate the total monetary value of fully filtered pending items. When the "pendiente" filter is applied, the main purple KPI card updates its title to "TOTAL PENDIENTE" and its value to the calculated sum, formatted as currency. When no such filter is applied, it reverts to the standard "Fondo Disponible" calculation.