### PR TITLE
fix(ui): prevent table row action menu from being clipped

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
             overscroll-behavior-x: contain;
             /* IMPORTANTE: mantiene inercia en iOS para scroll horizontal de tabla. */
             -webkit-overflow-scrolling: touch;
+            padding-bottom: 60px; /* Asegura espacio para los menús desplegables de las últimas filas */
         }
 
         .table {
@@ -367,11 +368,11 @@
             right: 0;
             top: calc(100% + 0.35rem);
             min-width: 240px;
-            z-index: 10;
+            z-index: 50;
             background: #fff;
             border: 1px solid #e2e8f0;
             border-radius: 0.75rem;
-            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
             padding: 0.75rem;
         }
 

--- a/server.log
+++ b/server.log
@@ -12,3 +12,10 @@
 127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/ui/dashboard.js HTTP/1.1" 200 -
 127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/ui/table.js HTTP/1.1" 200 -
 127.0.0.1 - - [26/Jun/2026 15:38:06] "GET /src/services/references.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /index.html HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/ui/table.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/ui/modals.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/services/references.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/services/payments.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/ui/dashboard.js HTTP/1.1" 200 -
+127.0.0.1 - - [26/Jun/2026 16:11:42] "GET /src/services/firebase.js HTTP/1.1" 200 -


### PR DESCRIPTION
Increase the z-index of the row expand panel and add bottom padding to the table container to ensure the action menu (three dots) is fully visible and not clipped by the overflow-x container boundaries.